### PR TITLE
ParserToken.cast fix

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -68,7 +68,6 @@ public interface ParserToken extends HasText {
      * Useful to get help reduce casting noise.
      */
     default <T extends ParserToken> T cast(final Class<T> type) {
-        //noinspection unchecked
-        return (T)this;
+        return type.cast(this);
     }
 }


### PR DESCRIPTION
- Class type parameter ignored, fix uses.
- TODO j2cl fix required.