### PR TITLE
walkingkooka-datetime/pull/25 LocaleDateTimeContext two-digit-year pa…

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java
@@ -168,7 +168,7 @@ public interface ParserTesting extends Testing {
     }
 
     default DateTimeContext dateTimeContext() {
-        return DateTimeContexts.locale(Locale.ENGLISH, 1920);
+        return DateTimeContexts.locale(Locale.ENGLISH, 20);
     }
 
     default DecimalNumberContext decimalNumberContext() {


### PR DESCRIPTION
…rameter check

- https://github.com/mP1/walkingkooka-datetime/pull/25
- LocaleDateTimeContext two-digit-year parameter check