### PR TITLE
SequenceParserBuilder.build min 2 parsers requirement removed

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserBuilder.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserBuilder.java
@@ -43,11 +43,16 @@ public final class SequenceParserBuilder<C extends ParserContext> implements Bui
         return this.add(SequenceParserRequiredComponent.with(parser));
     }
 
+    /**
+     * The build method will fail if no {@link Parsers} have been added.
+     */
     @Override
     public Parser<C> build() throws BuilderException {
-        if (this.components.size() < 2) {
-            throw new BuilderException("Sequence requires at least 2 parsers=" + this.components);
+        if (this.components.isEmpty()) {
+            throw new BuilderException("Sequence requires at least 1 parser");
         }
+
+        // no optimisation so results are always within a SequenceParserToken even with one child.
         return SequenceParser.with(this.components);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserBuilderTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserBuilderTest.java
@@ -43,6 +43,20 @@ public final class SequenceParserBuilderTest implements ClassTesting2<SequencePa
     }
 
     @Test
+    public void testOneOptionalParser() {
+        this.createBuilder()
+                .optional(PARSER1)
+                .build();
+    }
+
+    @Test
+    public void testOneRequiredParser() {
+        this.createBuilder()
+                .required(PARSER2)
+                .build();
+    }
+
+    @Test
     public void testMoreThanTwoParsers() {
         this.createBuilder()
                 .optional(PARSER1)


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/33
- SequenceParserBuilder.build() remove min: 2 parsers requirement