### PR TITLE
ParserTestingPrettyDumper when printing LeafParserToken should also p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ also contain methods to return details of their respective positions, including 
 
 
 
+## [ParserTesting](https://github.com/mP1/walkingkooka-text-cursor-parser/blob/master/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java)
+
+This interface contains numerous default methods which may be mixed in to any TestCase wishing to test a `Parser`. Examine 
+the [test cases](https://github.com/mP1/walkingkooka-text-cursor-parser/tree/master/src/test/java/walkingkooka/text/cursor/parser) for a few more advanced examples 
+
+- Tests become very succinct with little boilerplate.
+- Numerous overloads, supporting tests with minimum parameters, other requirements are defaulted.
+- The defaults come from factory methods.
+- `parseAndCheck` includes numerous asserts including a handy tree dump view when the result `ParserToken` does not match the expected. This view becomes particularly helpful when the ParserToken graph has many tokens.
+
+The dump print out view below shows a `SequenceParserToken` with 3 children. Each parent has its children indented and nested.
+
+```
+Sequence
+  String="a1" a1 (java.lang.String)
+  BigDecimal="1.5" 1.5 (java.math.BigDecimal)
+  BigInteger="23" 23 (java.math.BigInteger)
+
+```
+
+
+
 ## [Tests](https://github.com/mP1/walkingkooka-text-cursor-parser/tree/master/src/test/java/walkingkooka/text/cursor/parser)
 
 The test source contains many tests that accompany each and every parser and are a good read to better understand how

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumper.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumper.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.text.cursor.parser;
 
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
 import walkingkooka.text.printer.IndentingPrinter;
@@ -26,6 +27,21 @@ import java.util.Optional;
 
 /**
  * Used by {@link ParserTesting} to create an indented tree like value of {@link ParserToken tokens} in a tree.
+ * <pre>
+ * @Test
+ * public void testDumpSequenceParserToken() {
+ *     final List<ParserToken> tokens = Lists.of(ParserTokens.string("a1", "a1"),
+ *             ParserTokens.bigDecimal(BigDecimal.valueOf(1.5), "1.5"),
+ *             ParserTokens.bigInteger(BigInteger.valueOf(23), "23"));
+ *
+ *     this.dumpAndCheck(
+ *             ParserTokens.sequence(tokens, ParserToken.text(tokens))
+ *             , "Sequence\n" +
+ *                     "  String=\"a1\" a1 (java.lang.String)\n" +
+ *                     "  BigDecimal=\"1.5\" 1.5 (java.math.BigDecimal)\n" +
+ *                     "  BigInteger=\"23\" 23 (java.math.BigInteger)\n");
+ * }
+ * </pre>
  */
 final class ParserTestingPrettyDumper {
 
@@ -57,7 +73,14 @@ final class ParserTestingPrettyDumper {
 
     private static void dumpLeaf(final LeafParserToken token,
                                  final IndentingPrinter printer) {
-        printer.print(typeName(token) + "=" + token);
+        final Object value = token.value();
+        printer.print(
+                typeName(token) + "=" +
+                        CharSequences.quoteIfChars(token.text()) + " " + value +
+                        (null != value ?
+                                (" (" + value.getClass().getName() + ")") :
+                                "")
+        );
         printer.print(printer.lineEnding());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumperTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumperTest.java
@@ -32,9 +32,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public final class ParserTestingPrettyDumperTest implements ClassTesting2<ParserTestingPrettyDumper> {
 
     @Test
-    public void testDumpStringParserToken() {
-        this.dumpAndCheck(ParserTokens.string("abc123", "abc123"),
-                "String=abc123\n");
+    public void testDumpLeafParserTokenString() {
+        this.dumpAndCheck(
+                ParserTokens.string("abc123", "abc123"),
+                "String=\"abc123\" abc123 (java.lang.String)\n"
+        );
+    }
+
+    @Test
+    public void testDumpLeafParserTokenBigDecimal() {
+        this.dumpAndCheck(ParserTokens.bigDecimal(
+                BigDecimal.TEN, "different-text"),
+                "BigDecimal=\"different-text\" 10 (java.math.BigDecimal)\n"
+        );
     }
 
     @Test
@@ -46,9 +56,9 @@ public final class ParserTestingPrettyDumperTest implements ClassTesting2<Parser
         this.dumpAndCheck(
                 ParserTokens.sequence(tokens, ParserToken.text(tokens))
                 , "Sequence\n" +
-                        "  String=a1\n" +
-                        "  BigDecimal=1.5\n" +
-                        "  BigInteger=23\n");
+                        "  String=\"a1\" a1 (java.lang.String)\n" +
+                        "  BigDecimal=\"1.5\" 1.5 (java.math.BigDecimal)\n" +
+                        "  BigInteger=\"23\" 23 (java.math.BigInteger)\n");
     }
 
     private void dumpAndCheck(final ParserToken token,


### PR DESCRIPTION
…rint the value in parens

- tests with unequal tokens but equal dumps should now correctly fail.

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/35
- ParserTestingPrettyDumper when printing LeafParserToken should also print the value in parens