### PR TITLE
ParserTesting.checkEquals with pretty dump

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java
@@ -31,6 +31,7 @@ import java.math.MathContext;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -96,11 +97,13 @@ public interface ParserTesting extends Testing {
 
         final String textRemaining = after.textBetween().toString();
         if (false == token.equals(result)) {
-            assertEquals(ParserTestingPrettyDumper.dump(token),
-                    ParserTestingPrettyDumper.dump(result),
+            checkEquals(
+                    token,
+                    result,
                     () -> "text:\n" + CharSequences.quoteAndEscape(consumed.length() == 0 ?
                             after.textBetween() :
-                            consumed) + "\nunconsumed text:\n" + textRemaining);
+                            consumed) + "\nunconsumed text:\n" + textRemaining
+            );
         }
 
         assertEquals(text, consumed, "incorrect consumed text");
@@ -127,13 +130,35 @@ public interface ParserTesting extends Testing {
         if(result.isPresent()) {
             final TextCursorSavePoint after = cursor.save();
 
-            assertEquals(
-                    Optional.empty(),
-                    ParserTestingPrettyDumper.dump(result),
+            this.checkEquals(
+                    null,
+                    result.orElse(null),
                     () -> "Expected no token from parsing text consumed:\n" + before.textBetween() + "\ntext left: " + after.textBetween()
             );
         }
         return cursor;
+    }
+
+    // asserting ParserToken with pretty dump support...................................................................
+
+    default void checkEquals(final Optional<? extends ParserToken> expected,
+                             final Optional<? extends ParserToken> actual,
+                             final Supplier<String> message) {
+        assertEquals(
+                ParserTestingPrettyDumper.dump(expected.orElse(null)),
+                ParserTestingPrettyDumper.dump(actual.orElse(null)),
+                message
+        );
+    }
+
+    default void checkEquals(final ParserToken expected,
+                             final ParserToken actual,
+                             final Supplier<String> message) {
+        assertEquals(
+                ParserTestingPrettyDumper.dump(expected),
+                ParserTestingPrettyDumper.dump(actual),
+                message
+        );
     }
 
     // parseThrowsEndOfText.............................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumper.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumper.java
@@ -46,9 +46,10 @@ import java.util.Optional;
  */
 final class ParserTestingPrettyDumper {
 
-    static String dump(final Optional<ParserToken> token) {
-        return token.map(ParserTestingPrettyDumper::dump0)
-                .orElse(null);
+    static String dump(final ParserToken token) {
+        return null != token ?
+                dump0(token) :
+                null;
     }
 
     private static String dump0(final ParserToken token) {

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumperTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTestingPrettyDumperTest.java
@@ -72,7 +72,7 @@ public final class ParserTestingPrettyDumperTest implements ClassTesting2<Parser
     private void dumpAndCheck(final ParserToken token,
                               final String expected) {
         assertEquals(expected,
-                ParserTestingPrettyDumper.dump(Optional.of(token)),
+                ParserTestingPrettyDumper.dump(token),
                 () -> "" + token);
     }
 


### PR DESCRIPTION
- Can be used by other tests which wish to test ParserTokens for equality.