### PR TITLE
BasicParserReport: Invalid character '$char' at ($col,$row) message.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * A {@link ParserReporter} that builds an error message that looks something like:
  * <pre>
- * Unrecognized character 'X' at ... expected A | B | C
+ * Invalid character 'X' at ... expected A | B | C
  * </pre>
  */
 final class BasicParserReporter<C extends ParserContext> implements ParserReporter<C> {
@@ -62,7 +62,7 @@ final class BasicParserReporter<C extends ParserContext> implements ParserReport
         if (cursor.isEmpty()) {
             message.append("End of text");
         } else {
-            message.append("Unrecognized character ");
+            message.append("Invalid character ");
             message.append(CharSequences.quoteAndEscape(cursor.at()));
         }
         message.append(" at ");

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTesting2.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTesting2.java
@@ -114,7 +114,7 @@ public interface ParserTesting2<P extends Parser<C>,
                              final int column,
                              final int row) {
         // Message format from BasicParserReporter
-        this.parseThrows(cursorText, "Unrecognized character " + CharSequences.quoteAndEscape(c) + " at (" + column + "," + row + ")");
+        this.parseThrows(cursorText, "Invalid character " + CharSequences.quoteAndEscape(c) + " at (" + column + "," + row + ")");
     }
 
     default void parseThrowsEndOfText(final String cursorText) {

--- a/src/test/java/walkingkooka/text/cursor/parser/BasicParserReporterTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BasicParserReporterTest.java
@@ -30,7 +30,7 @@ public final class BasicParserReporterTest implements ClassTesting2<BasicParserR
     @Test
     public void testReport() {
         // has a dependency on the results of TextCursorLineInfo methods...
-        this.reportAndCheck("abc def ghi", Parsers.fake().setToString("ABC").cast(), "Unrecognized character 'a' at (1,1) \"abc def ghi\" expected ABC");
+        this.reportAndCheck("abc def ghi", Parsers.fake().setToString("ABC").cast(), "Invalid character 'a' at (1,1) \"abc def ghi\" expected ABC");
     }
 
     @Test
@@ -40,7 +40,7 @@ public final class BasicParserReporterTest implements ClassTesting2<BasicParserR
         cursor.next();
         cursor.next();
 
-        this.reportAndCheck(cursor, Parsers.fake().setToString("ABC").cast(), "Unrecognized character 'c' at (3,1) \"abc def ghi\" expected ABC");
+        this.reportAndCheck(cursor, Parsers.fake().setToString("ABC").cast(), "Invalid character 'c' at (3,1) \"abc def ghi\" expected ABC");
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
@@ -47,17 +47,19 @@ public final class ReportingParserTest extends ParserTestCase<ReportingParser<Pa
 
     @Test
     public void testReportFails() {
-        this.parseThrows("!", "Unrecognized");
+        this.parseThrows(
+                "!",
+                "Invalid character \'!\' at (1,1)"
+        );
     }
 
     @Test
     public void testNotEmptyConditionCursorEmptyNotFails() {
-        this.parseThrows(this.createParser(ParserReporterCondition.NOT_EMPTY), "!", "Unrecognized");
-    }
-
-    @Test
-    public void testNotEmptyConditionCursorNotEmptyParserFail() {
-        this.parseThrows(this.createParser(ParserReporterCondition.NOT_EMPTY), "!", "Unrecognized");
+        this.parseThrows(
+                this.createParser(ParserReporterCondition.NOT_EMPTY),
+                "!",
+                "Invalid character \'!\' at (1,1)"
+        );
     }
 
     @Test
@@ -76,7 +78,10 @@ public final class ReportingParserTest extends ParserTestCase<ReportingParser<Pa
     @Test
     @Override
     public void testEmptyCursorFail() {
-        this.parseThrows("!", "Unrecognized");
+        this.parseThrows(
+                "!",
+                "Invalid character \'!\' at (1,1)"
+        );
     }
 
     @Test


### PR DESCRIPTION
- Replaced "Unrecognized" with "Invalid" to match wording of InvalidCharacterException.getMessage()