### PR TITLE
StringCharPredicateParser.toString includes min/max

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/StringCharPredicateParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/StringCharPredicateParser.java
@@ -80,6 +80,11 @@ final class StringCharPredicateParser<C extends ParserContext> extends Parser2<C
 
     @Override
     public String toString() {
-        return this.predicate.toString();
+        return this.predicate.toString() +
+                '{' +
+                this.minLength +
+                ',' +
+                this.maxLength +
+                '}';
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/StringCharPredicateParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/StringCharPredicateParserTest.java
@@ -103,7 +103,10 @@ public class StringCharPredicateParserTest extends Parser2TestCase<StringCharPre
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createParser(), DIGITS.toString());
+        this.toStringAndCheck(
+                this.createParser(),
+                DIGITS + "{2,4}"
+        );
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues
- StringCharPredicateParser.toString() should include min/max