### PR TITLE
StringInitialAndPartCharPredicateParser.toString() includes-min & max

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/StringInitialAndPartCharPredicateParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/StringInitialAndPartCharPredicateParser.java
@@ -50,7 +50,7 @@ final class StringInitialAndPartCharPredicateParser<C extends ParserContext> ext
                 part,
                 minLength,
                 maxLength,
-                initial + " " + part
+                initial + " " + part + "{" + minLength + "," + maxLength + "}"
         );
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/StringInitialAndPartCharPredicateParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/StringInitialAndPartCharPredicateParserTest.java
@@ -133,7 +133,10 @@ public final class StringInitialAndPartCharPredicateParserTest extends NonEmptyP
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createParser(), INITIAL + " " + PART);
+        this.toStringAndCheck(
+                this.createParser(),
+                INITIAL + " " + PART + "{4,6}"
+        );
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/87
- StringInitialAndPartCharPredicateParser.toString() should include min/max in braces