### PR TITLE
ParserToken.children()

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -90,6 +90,16 @@ public interface ParserToken extends HasText,
     }
 
     /**
+     * Returns a {@link List} view of any children. Leaf {@link ParserToken} those that return true for {@link #isLeaf()} will return an empty {@link List}.
+     * Note this is not recursively it only returns the immediate children and NOT descendants.
+     */
+    default List<ParserToken> children() {
+        return this.isLeaf() ?
+                Lists.empty() :
+                ((Value<List<ParserToken>>) this).value();
+    }
+
+    /**
      * Called by the visitor responsible for this group of tokens, which typically resides in the same package.
      * The token must then call the appropriate visit or start/end visit and also visit any child token values as appropriate.
      */

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTesting.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTesting.java
@@ -199,6 +199,24 @@ public interface ParserTokenTesting<T extends ParserToken > extends BeanProperti
     }
 
     @Test
+    default void testChildren() {
+        final T token = this.createToken();
+        if (token.isLeaf()) {
+            this.checkEquals(
+                    Lists.empty(),
+                    token.children(),
+                    token + " children"
+            );
+        } else {
+            this.checkEquals(
+                    ((Value<List<ParserToken>>) token).value(),
+                    token.children(),
+                    token + " children"
+            );
+        }
+    }
+
+    @Test
     default void testAcceptStartParserTokenSkip() {
         final StringBuilder b = new StringBuilder();
         final List<ParserToken> visited = Lists.array();

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedOrSequenceParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedOrSequenceParserTokenTestCase.java
@@ -48,6 +48,21 @@ public abstract class RepeatedOrSequenceParserTokenTestCase<T extends RepeatedOr
         assertThrows(IllegalArgumentException.class, () -> this.createToken(Lists.empty(), "abc"));
     }
 
+    // children.........................................................................................................
+
+    @Test
+    public final void testChildren() {
+        final T token = this.createToken(STRING1, STRING2, STRING4);
+        this.checkEquals(
+                Lists.of(
+                        STRING1,
+                        STRING2,
+                        STRING4
+                ),
+                token.children()
+        );
+    }
+
     // flat............................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/122
- ParserToken.children() default method