### PR TITLE
BasicParserReport.toString() Fail

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
@@ -83,6 +83,6 @@ final class BasicParserReporter<C extends ParserContext> implements ParserReport
 
     @Override
     public String toString() {
-        return this.getClass().getSimpleName();
+        return "Fail";
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
@@ -97,7 +97,7 @@ public final class ReportingParserTest extends ParserWrapperTestCase<ReportingPa
     public void testToString() {
         this.toStringAndCheck(
                 this.createParser(),
-                "letter | BasicParserReporter"
+                "letter | Fail"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/120
- BasicReporterParser.toString() should include wrapped Parser.toString