### PR TITLE
ReportingParser unwrap given ReportingParser.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ReportingParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ReportingParser.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.text.cursor.parser;
 
+import walkingkooka.Cast;
 import walkingkooka.text.cursor.TextCursor;
 
 import java.util.Objects;
@@ -25,6 +26,9 @@ import java.util.Optional;
 /**
  * A {@link Parser} that acts as a bridge invoking a {@link ParserReporter}. The reporter will
  * typically throw an exception with a message noting a parse failure of the parser in this instance.
+ * <br>
+ * Note if the given {@link Parser} is also a {@link ReportingParser}, the wrapped {@link Parser} will be wrapped instead,
+ * ignoring that {@link ParserReporterCondition} and {@link ParserReporter}.
  */
 final class ReportingParser<C extends ParserContext> extends ParserWrapper<C> {
 
@@ -38,11 +42,17 @@ final class ReportingParser<C extends ParserContext> extends ParserWrapper<C> {
         Objects.requireNonNull(reporter, "reporter");
         checkParser(parser);
 
+        Parser<C> wrapped = parser;
+        if (parser instanceof ReportingParser) {
+            final ReportingParser<C> reportingParser = Cast.to(parser);
+            wrapped = reportingParser.parser;
+        }
+
         return new ReportingParser<>(
                 condition,
                 reporter,
-                parser,
-                parser + " | " + reporter
+                wrapped,
+                wrapped + " | " + reporter
         );
     }
 
@@ -75,9 +85,11 @@ final class ReportingParser<C extends ParserContext> extends ParserWrapper<C> {
                 this.report(cursor, context);
     }
 
-    private final ParserReporterCondition condition;
+    // @VisibleForTesting
+    final ParserReporterCondition condition;
 
-    private final ParserReporter<C> reporter;
+    // @VisibleForTesting
+    final ParserReporter<C> reporter;
 
     // ParserSetToString..........................................................................................................
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
@@ -24,6 +24,7 @@ import walkingkooka.text.cursor.TextCursors;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ReportingParserTest extends ParserWrapperTestCase<ReportingParser<ParserContext>> {
@@ -51,6 +52,49 @@ public final class ReportingParserTest extends ParserWrapperTestCase<ReportingPa
                         null,
                         this.wrappedParser()
                 )
+        );
+    }
+
+    @Test
+    public void testWrapReportingParser() {
+        final Parser<FakeParserContext> parser = Parsers.fake();
+        final ParserReporter<FakeParserContext> reporter = ParserReporters.fake();
+
+        final ReportingParser<FakeParserContext> reportingParser = ReportingParser.with(
+                ParserReporterCondition.ALWAYS,
+                reporter,
+                parser
+        );
+
+        final ParserReporterCondition condition = ParserReporterCondition.NOT_EMPTY;
+
+        final ReportingParser<FakeParserContext> reportingParser2 = ReportingParser.with(
+                condition,
+                reporter,
+                reportingParser
+        );
+
+        assertNotSame(
+                reportingParser,
+                reportingParser2
+        );
+
+        this.checkEquals(
+                parser,
+                reportingParser2.parser,
+                "parser"
+        );
+
+        this.checkEquals(
+                condition,
+                reportingParser2.condition,
+                "condition"
+        );
+
+        this.checkEquals(
+                reporter,
+                reportingParser2.reporter,
+                "reporter"
         );
     }
 


### PR DESCRIPTION
- When unwrapping the wrapped condition and ParserReporter are ignored and only the wrapped Parser kept.

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/119
- BasicParserReporter should not wrap another BasicParserReporter