### PR TITLE
ParserToken.removeFirstIf/removeIf default methods

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BigDecimalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigDecimalParserToken.java
@@ -21,7 +21,6 @@ import walkingkooka.text.printer.IndentingPrinter;
 
 import java.math.BigDecimal;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -39,28 +38,6 @@ public final class BigDecimalParserToken extends LeafParserToken<BigDecimal> {
 
     private BigDecimalParserToken(final BigDecimal value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<BigDecimalParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                BigDecimalParserToken.class
-        );
-    }
-
-    // removeIf....................................................................................................
-
-    @Override
-    public Optional<BigDecimalParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                BigDecimalParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.math.BigInteger;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -36,28 +35,6 @@ public final class BigIntegerParserToken extends LeafParserToken<BigInteger> {
 
     private BigIntegerParserToken(final BigInteger value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<BigIntegerParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                BigIntegerParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<BigIntegerParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                BigIntegerParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/CharacterParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/CharacterParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,28 +33,6 @@ public final class CharacterParserToken extends LeafParserToken<Character> {
 
     private CharacterParserToken(final char value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<CharacterParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                CharacterParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<CharacterParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                CharacterParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/DoubleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DoubleParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,28 +33,6 @@ public final class DoubleParserToken extends LeafParserToken<Double> {
 
     private DoubleParserToken(final Double value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<DoubleParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                DoubleParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<DoubleParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                DoubleParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/DoubleQuotedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DoubleQuotedParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -39,28 +38,6 @@ public final class DoubleQuotedParserToken extends QuotedParserToken {
 
     private DoubleQuotedParserToken(final String value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<DoubleQuotedParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                DoubleQuotedParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<DoubleQuotedParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                DoubleQuotedParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/LocalDateParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LocalDateParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.time.LocalDate;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class LocalDateParserToken extends LeafParserToken<LocalDate> {
 
     private LocalDateParserToken(final LocalDate value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<LocalDateParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                LocalDateParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<LocalDateParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                LocalDateParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/LocalDateTimeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LocalDateTimeParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class LocalDateTimeParserToken extends LeafParserToken<LocalDateTim
 
     private LocalDateTimeParserToken(final LocalDateTime value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<LocalDateTimeParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                LocalDateTimeParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<LocalDateTimeParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                LocalDateTimeParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/LocalTimeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LocalTimeParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.time.LocalTime;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class LocalTimeParserToken extends LeafParserToken<LocalTime> {
 
     private LocalTimeParserToken(final LocalTime value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<LocalTimeParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                LocalTimeParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<LocalTimeParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                LocalTimeParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/LongParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LongParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,28 +33,6 @@ public final class LongParserToken extends LeafParserToken<Long> {
 
     private LongParserToken(final Long value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<LongParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                LongParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<LongParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                LongParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/OffsetDateTimeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/OffsetDateTimeParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class OffsetDateTimeParserToken extends LeafParserToken<OffsetDateT
 
     private OffsetDateTimeParserToken(final OffsetDateTime value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<OffsetDateTimeParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                OffsetDateTimeParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<OffsetDateTimeParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                OffsetDateTimeParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/OffsetTimeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/OffsetTimeParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.time.OffsetTime;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class OffsetTimeParserToken extends LeafParserToken<OffsetTime> {
 
     private OffsetTimeParserToken(final OffsetTime value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<OffsetTimeParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                OffsetTimeParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<OffsetTimeParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                OffsetTimeParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -201,87 +201,16 @@ public interface ParserToken extends HasText,
      * this, while parents will search all descendants starting with their children. If a parent requires at least one child
      * and that child is removed then any thrown {@link Throwable} will still happen.
      */
-    Optional<? extends ParserToken> removeFirstIf(final Predicate<ParserToken> predicate);
-
-    /**
-     * Walks a graph of {@link ParserToken} attempting to find and then removing a matching child from its parent.
-     */
-    static <T extends ParserToken> Optional<T> removeFirstIfLeaf(final T token,
-                                                                 final Predicate<ParserToken> predicate,
-                                                                 final Class<T> type) {
-        checkToken(token);
-        checkPredicate(predicate);
-        checkType(type);
-
-        return predicate.test(token) ?
-                Optional.empty() :
-                Optional.of(token);
-    }
-
-    /**
-     * Walks a graph of {@link ParserToken} attempting to find and then removing a matching child from its parent.
-     */
-    static <T extends ParserToken> Optional<T> removeFirstIfParent(final T parent,
-                                                                   final Predicate<ParserToken> predicate,
-                                                                   final Class<T> type) {
-        checkParent(parent);
-        checkPredicate(predicate);
-        checkType(type);
-
-        Optional<T> result = null;
-
-        if (predicate.test(parent)) {
-            result = Optional.empty();
-        } else {
-            int i = 0;
-
-            final List<ParserToken> children = parent.children();
-            for (final ParserToken child : children) {
-                final Optional<ParserToken> childResult = (Optional<ParserToken>) child.removeFirstIf(predicate);
-                final int count = children.size();
-
-                if (childResult.isPresent()) {
-                    final ParserToken childResultParserToken = childResult.get();
-                    if (false == child.equals(childResultParserToken)) {
-                        final List<ParserToken> newChildren = Lists.array();
-
-                        newChildren.addAll(children.subList(0, i));
-                        newChildren.add(childResultParserToken);
-                        newChildren.addAll(children.subList(i + 1, count));
-
-                        result = Optional.of(
-                                (T) parent.setChildren(newChildren)
-                        );
-                        break; // child changed, must have been a remove so stop
-                    }
-
-                    // continue;
-                } else {
-                    if (1 == count) {
-                        result = Optional.empty();
-                    } else {
-                        final List<ParserToken> without = Lists.array();
-
-                        without.addAll(children.subList(0, i));
-                        // i = removed, skip adding.
-                        without.addAll(children.subList(i + 1, count));
-
-                        result = Optional.of(
-                                (T) parent.setChildren(without)
-                        );
-                    }
-                    break;
-                }
-
-                i++;
-            }
-
-            if (null == result) {
-                result = Optional.of(parent);
-            }
-        }
-
-        return result;
+    default Optional<ParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
+        return this.isLeaf() ?
+                ParserTokens.removeFirstIfLeaf(
+                        this,
+                        predicate
+                ) :
+                ParserTokens.removeFirstIfParent(
+                        this,
+                        predicate
+                );
     }
 
     // removeIf.........................................................................................................
@@ -291,59 +220,16 @@ public interface ParserToken extends HasText,
      * this, while parents will search all descendants starting with their children. If a parent requires at least one child
      * and that child is removed then any thrown {@link Throwable} will still happen.
      */
-    Optional<? extends ParserToken> removeIf(final Predicate<ParserToken> predicate);
-
-    /**
-     * Walks a graph of {@link ParserToken} attempting to find and then removing all matching tokens within the graph..
-     */
-    static <T extends ParserToken> Optional<T> removeIfLeaf(final T token,
-                                                            final Predicate<ParserToken> predicate,
-                                                            final Class<T> type) {
-        checkToken(token);
-        checkPredicate(predicate);
-        checkType(type);
-
-        return predicate.test(token) ?
-                Optional.empty() :
-                Optional.of(token);
-    }
-
-    /**
-     * Walks a graph of {@link ParserToken} attempting to find and then removing all matching tokens within the graph.
-     */
-    static <T extends ParserToken> Optional<T> removeIfParent(final T parent,
-                                                              final Predicate<ParserToken> predicate,
-                                                              final Class<T> type) {
-        checkParent(parent);
-        checkPredicate(predicate);
-        checkType(type);
-
-        Optional<T> result;
-
-        if (predicate.test(parent)) {
-            result = Optional.empty();
-        } else {
-
-            final List<ParserToken> children = parent.children();
-            final List<ParserToken> newChildren = Lists.array();
-
-            for (final ParserToken child : children) {
-                final Optional<ParserToken> childResult = (Optional<ParserToken>) child.removeIf(predicate);
-                if (childResult.isPresent()) {
-                    newChildren.add(childResult.get());
-                }
-            }
-
-            if (newChildren.isEmpty()) {
-                result = Optional.empty();
-            } else {
-                result = Optional.of(
-                        (T) parent.setChildren(newChildren)
+    default Optional<ParserToken> removeIf(final Predicate<ParserToken> predicate) {
+        return this.isLeaf() ?
+                ParserTokens.removeIfLeaf(
+                        this,
+                        predicate
+                ) :
+                ParserTokens.removeIfParent(
+                        this,
+                        predicate
                 );
-            }
-        }
-
-        return result;
     }
 
     // replaceFirstIf....................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTesting.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTesting.java
@@ -274,38 +274,13 @@ public interface ParserTokenTesting<T extends ParserToken > extends BeanProperti
     // removeFirstIf....................................................................................................
 
     @Test
-    default void testRemoveFirstIfParentNullTokenFails() {
+    default void testRemoveFirstIfNullPredicateFails() {
         assertThrows(
                 NullPointerException.class,
-                () -> ParserToken.removeFirstIfParent(
-                        null,
-                        Predicates.fake(),
-                        ParserToken.class
-                )
-        );
-    }
-
-    @Test
-    default void testRemoveFirstIfParentNullPredicateFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> ParserToken.removeFirstIfParent(
-                        this.createToken(),
-                        null,
-                        ParserToken.class
-                )
-        );
-    }
-
-    @Test
-    default void testRemoveFirstIfParentNullTypeFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> ParserToken.removeFirstIfParent(
-                        this.createToken(),
-                        Predicates.fake(),
-                        null
-                )
+                () -> this.createToken()
+                        .removeIf(
+                                null
+                        )
         );
     }
 
@@ -454,42 +429,6 @@ public interface ParserTokenTesting<T extends ParserToken > extends BeanProperti
     }
 
     // removeIf.........................................................................................................
-
-    @Test
-    default void testRemoveIfParentNullTokenFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> ParserToken.removeIfParent(
-                        null,
-                        Predicates.fake(),
-                        ParserToken.class
-                )
-        );
-    }
-
-    @Test
-    default void testRemoveIfParentNullPredicateFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> ParserToken.removeIfParent(
-                        this.createToken(),
-                        null,
-                        ParserToken.class
-                )
-        );
-    }
-
-    @Test
-    default void testRemoveIfParentNullTypeFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> ParserToken.removeIfParent(
-                        this.createToken(),
-                        Predicates.fake(),
-                        null
-                )
-        );
-    }
 
     @Test
     default void testRemoveIfNone() {

--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
@@ -20,7 +20,6 @@ import walkingkooka.visit.Visiting;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -58,28 +57,6 @@ public final class RepeatedParserToken extends RepeatedOrSequenceParserToken {
                 this,
                 children,
                 RepeatedParserToken::new
-        );
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<RepeatedParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfParent(
-                this,
-                predicate,
-                RepeatedParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<RepeatedParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfParent(
-                this,
-                predicate,
-                RepeatedParserToken.class
         );
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
@@ -21,7 +21,6 @@ import walkingkooka.visit.Visiting;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -160,28 +159,6 @@ public final class SequenceParserToken extends RepeatedOrSequenceParserToken {
                 this,
                 children,
                 SequenceParserToken::new
-        );
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<SequenceParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfParent(
-                this,
-                predicate,
-                SequenceParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<SequenceParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfParent(
-                this,
-                predicate,
-                SequenceParserToken.class
         );
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/SignParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SignParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,28 +33,6 @@ public final class SignParserToken extends LeafParserToken<Boolean> {
 
     private SignParserToken(final boolean value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<SignParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                SignParserToken.class
-        );
-    }
-
-    // removeIf........................................................................................................
-
-    @Override
-    public Optional<SignParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                SignParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/SingleQuotedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SingleQuotedParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -39,28 +38,6 @@ public final class SingleQuotedParserToken extends QuotedParserToken {
 
     private SingleQuotedParserToken(final String value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<SingleQuotedParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                SingleQuotedParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<SingleQuotedParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                SingleQuotedParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/StringParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/StringParserToken.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class StringParserToken extends LeafParserToken<String> {
 
     private StringParserToken(final String value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<StringParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                StringParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<StringParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                StringParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/ZonedDateTimeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ZonedDateTimeParserToken.java
@@ -18,7 +18,6 @@ package walkingkooka.text.cursor.parser;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,28 +34,6 @@ public final class ZonedDateTimeParserToken extends LeafParserToken<ZonedDateTim
 
     private ZonedDateTimeParserToken(final ZonedDateTime value, final String text) {
         super(value, text);
-    }
-
-    // removeFirstIf....................................................................................................
-
-    @Override
-    public Optional<ZonedDateTimeParserToken> removeFirstIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeFirstIfLeaf(
-                this,
-                predicate,
-                ZonedDateTimeParserToken.class
-        );
-    }
-
-    // removeIf.........................................................................................................
-
-    @Override
-    public Optional<ZonedDateTimeParserToken> removeIf(final Predicate<ParserToken> predicate) {
-        return ParserToken.removeIfLeaf(
-                this,
-                predicate,
-                ZonedDateTimeParserToken.class
-        );
     }
 
     // replaceFirstIf...................................................................................................


### PR DESCRIPTION
- No longer abstract, all sub-classes no longer need to @Override.

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/173
- ParserToken.removeIf implement default & delete ParserTokens.removeIf

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/172
- ParserToken.removeFirstIf implement default & delete ParserTokens.removeFirstIf