### PR TITLE
SurroundStringParser.hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/SurroundStringParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SurroundStringParser.java
@@ -20,6 +20,7 @@ import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursorSavePoint;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -119,5 +120,28 @@ final class SurroundStringParser<C extends ParserContext> extends NonEmptyParser
                 this.close,
                 toString
         );
+    }
+
+    // Object...........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.open,
+                this.close,
+                this.toString
+        );
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof SurroundStringParser && this.equals0((SurroundStringParser<?>) other);
+    }
+
+    private boolean equals0(final SurroundStringParser<?> other) {
+        return this.open.equals(other.open) &&
+                this.close.equals(other.close) &&
+                this.toString.equals(other.toString);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/SurroundStringParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SurroundStringParserTest.java
@@ -18,11 +18,13 @@ package walkingkooka.text.cursor.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.text.CharSequences;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SurroundStringParserTest extends NonEmptyParserTestCase<SurroundStringParser<ParserContext>, StringParserToken> {
+public class SurroundStringParserTest extends NonEmptyParserTestCase<SurroundStringParser<ParserContext>, StringParserToken>
+        implements HashCodeEqualsDefinedTesting2<SurroundStringParser<ParserContext>> {
 
     private final static String OPEN = "<123";
     private final static String CLOSE = "456";
@@ -127,6 +129,35 @@ public class SurroundStringParserTest extends NonEmptyParserTestCase<SurroundStr
     public SurroundStringParser<ParserContext> createParser() {
         return SurroundStringParser.with(OPEN, CLOSE);
     }
+
+    // hashCode/equals...................................................................................................
+
+    @Test
+    public void testDifferentOpen() {
+        this.checkNotEquals(
+                SurroundStringParser.with(
+                        "different",
+                        CLOSE
+                )
+        );
+    }
+
+    @Test
+    public void testDifferentClose() {
+        this.checkNotEquals(
+                SurroundStringParser.with(
+                        OPEN,
+                        "different"
+                )
+        );
+    }
+
+    @Override
+    public SurroundStringParser<ParserContext> createObject() {
+        return this.createParser();
+    }
+
+    // Class............................................................................................................
 
     @Override
     public Class<SurroundStringParser<ParserContext>> type() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/200
- SurroundStringParser should implement hashCode/equals