### PR TITLE
ReportingParser hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ReportingParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ReportingParser.java
@@ -102,4 +102,27 @@ final class ReportingParser<C extends ParserContext> extends ParserWrapper<C> {
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.condition,
+                this.reporter,
+                this.parser
+        );
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof ReportingParser && this.equals0((ReportingParser<?>) other);
+    }
+
+    private boolean equals0(final ReportingParser<?> other) {
+        return this.condition.equals(other.condition) &&
+                this.reporter.equals(other.reporter) &&
+                this.parser.equals(other.parser);
+    }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
@@ -19,6 +19,7 @@ package walkingkooka.text.cursor.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.cursor.TextCursors;
 
@@ -27,7 +28,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ReportingParserTest extends ParserWrapperTestCase<ReportingParser<ParserContext>> {
+public final class ReportingParserTest extends ParserWrapperTestCase<ReportingParser<ParserContext>>
+        implements HashCodeEqualsDefinedTesting2<ReportingParser<ParserContext>> {
 
     private final static ParserReporterCondition CONDITION = ParserReporterCondition.ALWAYS;
 
@@ -136,6 +138,63 @@ public final class ReportingParserTest extends ParserWrapperTestCase<ReportingPa
                 "Invalid character \'!\' at (1,1)"
         );
     }
+
+    // hashCode/equals..................................................................................................
+
+    @Test
+    public void testEqualsDifferentCondition() {
+        this.checkNotEquals(
+                ReportingParser.with(
+                        ParserReporterCondition.ALWAYS,
+                        this.reporter(),
+                        this.wrappedParser()
+                ),
+                ReportingParser.with(
+                        ParserReporterCondition.NOT_EMPTY,
+                        this.reporter(),
+                        this.wrappedParser()
+                )
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentReporter() {
+        this.checkNotEquals(
+                ReportingParser.with(
+                        ParserReporterCondition.ALWAYS,
+                        this.reporter(),
+                        this.wrappedParser()
+                ),
+                ReportingParser.with(
+                        ParserReporterCondition.ALWAYS,
+                        ParserReporters.fake(),
+                        this.wrappedParser()
+                )
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentParser() {
+        this.checkNotEquals(
+                ReportingParser.with(
+                        ParserReporterCondition.ALWAYS,
+                        this.reporter(),
+                        this.wrappedParser()
+                ),
+                ReportingParser.with(
+                        ParserReporterCondition.ALWAYS,
+                        this.reporter(),
+                        Parsers.fake()
+                )
+        );
+    }
+
+    @Override
+    public ReportingParser<ParserContext> createObject() {
+        return this.createParser();
+    }
+
+    // toString.........................................................................................................
 
     @Test
     public void testToString() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/195
- ReportingParser should implement hashCode/equals