### PR TITLE
StringCharPredicateParser.hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/StringCharPredicateParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/StringCharPredicateParser.java
@@ -106,4 +106,29 @@ final class StringCharPredicateParser<C extends ParserContext> extends NonEmptyP
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.predicate,
+                this.minLength,
+                this.maxLength,
+                this.toString
+        );
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof StringCharPredicateParser && this.equals0((StringCharPredicateParser<?>) other);
+    }
+
+    private boolean equals0(final StringCharPredicateParser<?> other) {
+        return this.predicate.equals(other.predicate) &&
+                this.minLength == other.minLength &&
+                this.maxLength == other.maxLength &&
+                this.toString.equals(other.toString);
+    }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/StringCharPredicateParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/StringCharPredicateParserTest.java
@@ -18,13 +18,15 @@ package walkingkooka.text.cursor.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.cursor.TextCursor;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class StringCharPredicateParserTest extends NonEmptyParserTestCase<StringCharPredicateParser<ParserContext>, StringParserToken> {
+public class StringCharPredicateParserTest extends NonEmptyParserTestCase<StringCharPredicateParser<ParserContext>, StringParserToken>
+        implements HashCodeEqualsDefinedTesting2<StringCharPredicateParser<ParserContext>> {
 
     private final static CharPredicate DIGITS = CharPredicates.digit();
     private final static int MIN_LENGTH = 2;
@@ -164,6 +166,79 @@ public class StringCharPredicateParserTest extends NonEmptyParserTestCase<String
     private TextCursor parseAndCheck3(final String in, final String value, final String text, final String textAfter) {
         return this.parseAndCheck(in, StringParserToken.with(value, text), text, textAfter);
     }
+
+    // hashCode/equals..................................................................................................
+
+    @Test
+    public void testEqualsDifferentPredicate() {
+        this.checkNotEquals(
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                ),
+                StringCharPredicateParser.with(
+                        CharPredicates.fake(),
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                )
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentMinLength() {
+        this.checkNotEquals(
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                ),
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH + 1,
+                        MAX_LENGTH
+                )
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentMaxLength() {
+        this.checkNotEquals(
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                ),
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH,
+                        MAX_LENGTH + 1
+                )
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentToString() {
+        this.checkNotEquals(
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                ),
+                StringCharPredicateParser.with(
+                        DIGITS,
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                ).setToString("Different")
+        );
+    }
+
+    @Override
+    public StringCharPredicateParser<ParserContext> createObject() {
+        return this.createParser();
+    }
+
+    // class............................................................................................................
 
     @Override
     public Class<StringCharPredicateParser<ParserContext>> type() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/205
- StringCharPredicateParser should implement hashCode/equals