### PR TITLE
DateTimeFormatterParser.hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParser.java
@@ -148,4 +148,27 @@ abstract class DateTimeFormatterParser<C extends ParserContext> extends NonEmpty
      */
     abstract ParserToken createParserToken(final TemporalAccessor temporalAccessor,
                                            final String text);
+
+    // Object...........................................................................................................
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(
+                this.formatter,
+                this.toString
+        );
+    }
+
+    @Override
+    public final boolean equals(final Object other) {
+        return this == other ||
+                this.canBeEqual(other) && this.equals0((DateTimeFormatterParser<?>) other);
+    }
+
+    abstract boolean canBeEqual(final Object other);
+
+    private boolean equals0(final DateTimeFormatterParser<?> other) {
+        return this.formatter.equals(other.formatter) &&
+                this.toString.equals(other.toString);
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserLocalDate.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserLocalDate.java
@@ -58,4 +58,11 @@ final class DateTimeFormatterParserLocalDate<C extends ParserContext> extends Da
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DateTimeFormatterParserLocalDate;
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserLocalDateTime.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserLocalDateTime.java
@@ -55,4 +55,11 @@ final class DateTimeFormatterParserLocalDateTime<C extends ParserContext> extend
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DateTimeFormatterParserLocalDateTime;
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserLocalTime.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserLocalTime.java
@@ -55,4 +55,11 @@ final class DateTimeFormatterParserLocalTime<C extends ParserContext> extends Da
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DateTimeFormatterParserLocalTime;
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserOffsetDateTime.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserOffsetDateTime.java
@@ -55,4 +55,11 @@ final class DateTimeFormatterParserOffsetDateTime<C extends ParserContext> exten
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DateTimeFormatterParserOffsetDateTime;
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserOffsetTime.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserOffsetTime.java
@@ -55,4 +55,11 @@ final class DateTimeFormatterParserOffsetTime<C extends ParserContext> extends D
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DateTimeFormatterParserOffsetTime;
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserZonedDateTime.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserZonedDateTime.java
@@ -55,4 +55,11 @@ final class DateTimeFormatterParserZonedDateTime<C extends ParserContext> extend
                 toString
         );
     }
+
+    // Object...........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DateTimeFormatterParserZonedDateTime;
+    }
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/206
- DateTimeFormatterParser sub classes should implement hashCode/equals