### PR TITLE
AndEmptyTextCursorParser.hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/AndEmptyTextCursorParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/AndEmptyTextCursorParser.java
@@ -71,4 +71,22 @@ final class AndEmptyTextCursorParser<C extends ParserContext> extends ParserWrap
                 toString
         );
     }
+
+    // Object..........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return this.parser.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof AndEmptyTextCursorParser && this.equals0((AndEmptyTextCursorParser<?>) other);
+    }
+
+    private boolean equals0(final AndEmptyTextCursorParser<?> other) {
+        return this.parser.equals(other.parser) &&
+                this.toString.equals(other.toString);
+    }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/AndEmptyTextCursorParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/AndEmptyTextCursorParserTest.java
@@ -18,11 +18,13 @@ package walkingkooka.text.cursor.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.text.CaseSensitivity;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public final class AndEmptyTextCursorParserTest extends ParserWrapperTestCase<AndEmptyTextCursorParser<ParserContext>> {
+public final class AndEmptyTextCursorParserTest extends ParserWrapperTestCase<AndEmptyTextCursorParser<ParserContext>>
+        implements HashCodeEqualsDefinedTesting2<AndEmptyTextCursorParser<ParserContext>> {
 
     private final static String STRING = "abc";
     private final static Parser<ParserContext> WRAPPED = Parsers.string(STRING, CaseSensitivity.SENSITIVE);
@@ -73,6 +75,31 @@ public final class AndEmptyTextCursorParserTest extends ParserWrapperTestCase<An
     Parser<ParserContext> wrappedParser() {
         return WRAPPED;
     }
+
+    // hashCode/Equals..................................................................................................
+
+    @Test
+    public void testEqualsDifferentParser() {
+        this.checkNotEquals(
+                AndEmptyTextCursorParser.with(Parsers.fake()),
+                AndEmptyTextCursorParser.with(Parsers.fake())
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentToString() {
+        this.checkNotEquals(
+                AndEmptyTextCursorParser.with(WRAPPED),
+                AndEmptyTextCursorParser.with(WRAPPED).setToString("different")
+        );
+    }
+
+    @Override
+    public AndEmptyTextCursorParser<ParserContext> createObject() {
+        return this.createParser();
+    }
+
+    // class............................................................................................................
 
     @Override
     public Class<AndEmptyTextCursorParser<ParserContext>> type() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/196
- AndEmptyTextCursorParser should implement hashCode/equals

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/193
- ParserWrapper and sub-classes should implement hashCode/equals