### PR TITLE
Parser.parseText cursor empty InvalidCharacterException FIX

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/Parser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parser.java
@@ -20,6 +20,7 @@ import walkingkooka.Cast;
 import walkingkooka.InvalidCharacterException;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursorLineInfo;
 import walkingkooka.text.cursor.TextCursors;
 
 import java.util.Objects;
@@ -49,10 +50,20 @@ public interface Parser<C extends ParserContext> {
                     context
             ).orElseThrow(() -> new InvalidCharacterException(text, 0));
         } catch (final ParserReporterException cause) {
+            final Throwable cause2 = cause.getCause();
+            if (cause2 instanceof RuntimeException) {
+                throw (RuntimeException) cause2;
+            }
+
+            final TextCursorLineInfo lineInfo = cause.lineInfo();
+
+            // lineInfo.textOffset could be passed the end of text, move back by one if it is.
             throw new InvalidCharacterException(
                     text,
-                    cause.lineInfo()
-                            .textOffset()
+                    Math.min(
+                            lineInfo.textOffset(),
+                            text.length() - 1
+                    )
             );
         } catch (final ParserException cause) {
             throw new IllegalArgumentException(cause.getCause());

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTest.java
@@ -58,7 +58,7 @@ public final class ParserTest implements ClassTesting<Parser<ParserContext>>,
     }
 
     @Test
-    public void testParseInvalidCharacterFails() {
+    public void testParseTextInvalidCharacterFails() {
         final String text = "1X2";
 
         this.parseStringFails(
@@ -71,7 +71,7 @@ public final class ParserTest implements ClassTesting<Parser<ParserContext>>,
     }
 
     @Test
-    public void testParseThrownException() {
+    public void testParseTextThrownException() {
         final String text = "'un-closed";
 
         assertThrows(
@@ -84,7 +84,7 @@ public final class ParserTest implements ClassTesting<Parser<ParserContext>>,
     }
 
     @Test
-    public void testParseReturnsEmpty() {
+    public void testParseTextConsumesTextReturnsEmpty() {
         final String text = "ABC123";
 
         final InvalidCharacterException thrown = assertThrows(
@@ -102,7 +102,60 @@ public final class ParserTest implements ClassTesting<Parser<ParserContext>>,
                 )
         );
         this.checkEquals(
-                new InvalidCharacterException(text, 0)
+                new InvalidCharacterException(
+                        text,
+                        0
+                ).getMessage(),
+                thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testParseTextReturnsEmpty() {
+        final String text = "ABC123";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> new Parser<ParserContext>() {
+                    @Override
+                    public Optional<ParserToken> parse(final TextCursor cursor,
+                                                       final ParserContext context) {
+                        return Optional.empty();
+                    }
+                }.parseText(
+                        text,
+                        ParserContexts.fake()
+                )
+        );
+        this.checkEquals(
+                new InvalidCharacterException(
+                        text,
+                        0
+                ).getMessage(),
+                thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testParseTextConsumesSomeReturnsEmpty() {
+        final String text = "ABC123";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> new Parser<ParserContext>() {
+                    @Override
+                    public Optional<ParserToken> parse(final TextCursor cursor,
+                                                       final ParserContext context) {
+                        cursor.next();
+                        return Optional.empty();
+                    }
+                }.parseText(
+                        text,
+                        ParserContexts.fake()
+                )
+        );
+        this.checkEquals(
+                new InvalidCharacterException(text, 1)
                         .getMessage(),
                 thrown.getMessage()
         );
@@ -116,7 +169,8 @@ public final class ParserTest implements ClassTesting<Parser<ParserContext>>,
                         ParserContexts.basic(
                                 DateTimeContexts.fake(),
                                 DecimalNumberContexts.american(MathContext.DECIMAL32)
-                        ));
+                        )
+                );
     }
 
     @Override


### PR DESCRIPTION
- Previously if the TextCursor was empty (at its end), returning Optional#empty throw InvalidCharacterException would fail because textOffset is > text.length