### PR TITLE
ParserToken.printTree java literal print support

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -307,18 +307,43 @@ public interface ParserToken extends CanBeEmpty,
         if (this.isLeaf()) {
             final Object value = ((Value<?>) this).value();
 
+            final CharSequence toString;
+
+            if (null != value) {
+                final String typeName = value.getClass().getName();
+                switch (typeName) {
+                    case "java.lang.Boolean":
+                    case "java.lang.Double":
+                    case "java.lang.Integer":
+                        toString = value.toString();
+                        break;
+                    case "java.lang.Character":
+                    case "java.lang.String":
+                        toString = CharSequences.quoteIfChars(value);
+                        break;
+                    case "java.lang.Float":
+                        toString = value + "F";
+                        break;
+                    case "java.lang.Long":
+                        toString = value + "L";
+                        break;
+                    default:
+                        toString = CharSequences.quoteIfChars(value) +
+                                " (" +
+                                typeName +
+                                ")";
+                        break;
+                }
+            } else {
+                toString = null;
+            }
+
             printer.println(
                     ParserTokenTypeName.typeName(this) +
                             " " +
                             quotedText +
                             " " +
-                            (null == value ?
-                                    null :
-                                    CharSequences.quoteIfChars(value) +
-                                            " (" +
-                                            value.getClass().getName() +
-                                            ")"
-                            )
+                            toString
             );
         }
         if (this.isParent()) {

--- a/src/test/java/walkingkooka/text/cursor/parser/CharacterParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/CharacterParserTokenTest.java
@@ -55,7 +55,7 @@ public final class CharacterParserTokenTest extends ValueParserTokenTestCase<Cha
     public void testPrintTree() {
         this.treePrintAndCheck(
                 this.createToken(),
-                "Character \"\\'A\\'\" 'A' (java.lang.Character)\n"
+                "Character \"\\'A\\'\" 'A'\n"
         );
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.printer.TreePrintableTesting;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -1660,6 +1661,132 @@ public final class ParserTokenTest implements ClassTesting<ParserToken>, TreePri
                 Lists.of(new LinkedHashSet<>(expected).toArray()),
                 () -> "Expected no duplicates"
         );
+    }
+
+    // TreePrintable....................................................................................................
+
+    @Test
+    public void testTreePrintBigDecimal() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        new BigDecimal("123.5"),
+                        "123.5"
+                ),
+                "TestLeaf \"123.5\" 123.5 (java.math.BigDecimal)\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintBoolean() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        true,
+                        "true"
+                ),
+                "TestLeaf \"true\" true\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintCharacter() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        'A',
+                        "A"
+                ),
+                "TestLeaf \"A\" 'A'\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintDouble() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        1.5,
+                        "1.5"
+                ),
+                "TestLeaf \"1.5\" 1.5\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintFloat() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        1.25f,
+                        "1.25"
+                ),
+                "TestLeaf \"1.25\" 1.25F\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintInteger() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        123,
+                        "123"
+                ),
+                "TestLeaf \"123\" 123\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintLong() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        234L,
+                        "234"
+                ),
+                "TestLeaf \"234\" 234L\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintString() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        "abc",
+                        "\"abc\""
+                ),
+                "TestLeaf \"abc\" \"abc\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintStringBuilder() {
+        this.treePrintAndCheck(
+                new TestLeafParserToken(
+                        new StringBuilder("def"),
+                        "\"def\""
+                ),
+                "TestLeaf \"def\" \"def\" (java.lang.StringBuilder)\n"
+        );
+    }
+
+    static final class TestLeafParserToken<T> extends LeafParserToken<T> {
+
+        TestLeafParserToken(final T value,
+                            final String text) {
+            super(
+                    value,
+                    text
+            );
+        }
+
+        @Override
+        public final void accept(final ParserTokenVisitor visitor) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override final boolean canBeEqual(final Object other) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        boolean equals1(final ValueParserToken<?> other) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
@@ -122,7 +122,7 @@ public final class RepeatedParserTokenTest extends RepeatedOrSequenceParserToken
         this.treePrintAndCheck(
                 this.createToken(),
                 "Repeated \"abc\"\n" +
-                        "  String \"abc\" \"abc\" (java.lang.String)\n"
+                        "  String \"abc\" \"abc\"\n"
         );
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
@@ -615,8 +615,8 @@ public final class SequenceParserTokenTest extends RepeatedOrSequenceParserToken
         this.treePrintAndCheck(
                 this.createToken(),
                 "Sequence \"a1b2\"\n" +
-                        "  String \"a1\" \"a1\" (java.lang.String)\n" +
-                        "  String \"b2\" \"b2\" (java.lang.String)\n"
+                        "  String \"a1\" \"a1\"\n" +
+                        "  String \"b2\" \"b2\"\n"
         );
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/StringParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/StringParserTokenTest.java
@@ -61,7 +61,7 @@ public final class StringParserTokenTest extends ValueParserTokenTestCase<String
     public void testPrintTree() {
         this.treePrintAndCheck(
                 this.createToken(),
-                "String \"abc\" \"abc\" (java.lang.String)\n"
+                "String \"abc\" \"abc\"\n"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/237
- ParserToken#printTree shouldnt print class type for basic types boolean/String/char/int/long/float/double