### PR TITLE
RepeatingParser unwrapped optional FIX

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatingParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatingParser.java
@@ -191,6 +191,8 @@ final class RepeatingParser<C extends ParserContext> extends NonEmptyParser<C> {
                                    final C context,
                                    final TextCursorSavePoint start) {
         final Parser<C> parser = this.parser;
+        final int maxCount = this.maxCount;
+
         List<ParserToken> tokens = null; // lazily create
 
         for (; ; ) {
@@ -205,7 +207,7 @@ final class RepeatingParser<C extends ParserContext> extends NonEmptyParser<C> {
                 tokens = Lists.array();
             }
             tokens.add(maybe.get());
-            if (tokens.size() == this.maxCount) {
+            if (tokens.size() == maxCount) {
                 break;
             }
         }
@@ -214,7 +216,7 @@ final class RepeatingParser<C extends ParserContext> extends NonEmptyParser<C> {
                 null == tokens || tokens.size() < this.minCount ?
                         null :
                         // if this parser is optional min=0 & max=1 DONT wrap the only matched token in a RepeatingParserToken
-                        this.isOptional() ?
+                        this.isOptional() && 1 == maxCount ?
                                 optionalResult(tokens) :
                                 nonOptionalResult(
                                         tokens,

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatingParserTest.java
@@ -274,6 +274,30 @@ public class RepeatingParserTest extends NonEmptyParserTestCase<RepeatingParser<
     }
 
     @Test
+    public void testParseMinCount0AndMaxCount2() {
+        final String text = TEXT + TEXT;
+        final String after = "!!!";
+
+        this.parseAndCheck(
+                RepeatingParser.with(
+                        0, // min
+                        2, // max
+                        PARSER
+                ),
+                text + after,
+                RepeatedParserToken.with(
+                        Lists.of(
+                                string(TEXT),
+                                string(TEXT)
+                        ),
+                        text
+                ),
+                text,
+                after
+        );
+    }
+
+    @Test
     public void testParseOptionalMinCount0AndMaxCount1() {
         final String text = TEXT;
         final String after = "!!!";


### PR DESCRIPTION
- Fixes the previous commit which would fail for repeating min=0 & max>1 as it would only return the first token and lost the trailing.