### PR TITLE
AlternativeParser/SequenceParser.toString changed auto parens

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParser.java
@@ -82,20 +82,34 @@ final class SequenceParser<C extends ParserContext> extends NonEmptyParser<C>
     }
 
     /**
-     * Concats all parsers separated by comma, and surrounding the sequence with grouping parens.
+     * Concats all parsers separated by comma, any {@link AlternativesParser} will have extra grouping parens around them.
      * <pre>
      * (A, B, C)
      * </pre>
      */
     static <C extends ParserContext> String buildToString(final List<Parser<C>> parsers) {
         return parsers.stream()
-                .map(Object::toString)
+                .map(SequenceParser::parserToString)
                 .collect(Collectors.joining(
-                                ", ",
-                                "(",
-                                ")"
+                        ", "
                         )
                 );
+    }
+
+    /**
+     * Only add grouping parens if any {@link AlternativesParser} has a NON custom {@link Object#toString()}.
+     */
+    private static <C extends ParserContext> String parserToString(final Parser<C> parser) {
+        String toString = parser.toString();
+
+        if (parser instanceof AlternativesParser) {
+            final AlternativesParser<?> alternativesParser = parser.cast();
+            if (false == alternativesParser.customToString) {
+                toString = "(" + toString + ")";
+            }
+        }
+
+        return toString;
     }
 
     private SequenceParser(final List<Parser<C>> parsers,
@@ -166,4 +180,6 @@ final class SequenceParser<C extends ParserContext> extends NonEmptyParser<C>
                 toString
         );
     }
+
+    boolean customToString;
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
@@ -32,8 +32,13 @@ public class AlternativesParserTest extends ParserTestCase<AlternativesParser<Pa
 
     private final static String TEXT1 = "abc";
     private final static String TEXT2 = "xyz";
+    private final static String TEXT3 = "333";
+    private final static String TEXT4 = "444";
+
     private final static Parser<ParserContext> PARSER1 = parser(TEXT1);
     private final static Parser<ParserContext> PARSER2 = parser(TEXT2);
+    private final static Parser<ParserContext> PARSER3 = parser(TEXT3);
+    private final static Parser<ParserContext> PARSER4 = parser(TEXT4);
 
     @Test
     public void testWithNullParsersFails() {
@@ -97,7 +102,7 @@ public class AlternativesParserTest extends ParserTestCase<AlternativesParser<Pa
                 "parsers"
         );
         this.checkEquals(
-                "(1 | 2)",
+                "1 | 2",
                 custom.toString(),
                 "custom toString"
         );
@@ -250,7 +255,26 @@ public class AlternativesParserTest extends ParserTestCase<AlternativesParser<Pa
     public void testToString() {
         this.toStringAndCheck(
                 this.createParser(),
-                "(" + PARSER1 + " | " + PARSER2 + ")"
+                PARSER1 + " | " + PARSER2
+        );
+    }
+
+    @Test
+    public void testToStringSurroundSequenceParser() {
+        this.toStringAndCheck(
+                AlternativesParser.with(
+                        Lists.of(
+                                PARSER1,
+                                SequenceParser.with(
+                                        Lists.of(
+                                                PARSER2,
+                                                PARSER3
+                                        )
+                                ),
+                                PARSER4
+                        )
+                ),
+                PARSER1 + " | (" + PARSER2 + ", " + PARSER3 + ") | " + PARSER4
         );
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserBuilderTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserBuilderTest.java
@@ -81,11 +81,13 @@ public final class SequenceParserBuilderTest implements ClassTesting2<SequencePa
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createBuilder()
+        this.toStringAndCheck(
+                this.createBuilder()
                         .optional(PARSER1)
                         .required(PARSER2)
                         .required(PARSER3),
-                "([" + PARSER1 + "], " + PARSER2 + ", " + PARSER3 + ")");
+                "[" + PARSER1 + "], " + PARSER2 + ", " + PARSER3
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTest.java
@@ -286,7 +286,7 @@ public final class SequenceParserTest extends NonEmptyParserTestCase<SequencePar
     public void testToString() {
         this.toStringAndCheck(
                 this.createParser(),
-                "(" + PARSER1 + ", " + PARSER2 + ", [" + PARSER3 + "])"
+                PARSER1 + ", " + PARSER2 + ", [" + PARSER3 + "]"
         );
     }
 
@@ -305,7 +305,7 @@ public final class SequenceParserTest extends NonEmptyParserTestCase<SequencePar
                                 PARSER4
                         )
                 ),
-                "(" + PARSER1 + ", " + PARSER2 + ", " + PARSER3 + ", " + PARSER4 + ")"
+                PARSER1 + ", " + PARSER2 + ", " + PARSER3 + ", " + PARSER4
         );
     }
 
@@ -329,7 +329,26 @@ public final class SequenceParserTest extends NonEmptyParserTestCase<SequencePar
                                 parser("@@@")
                         )
                 ),
-                "(" + PARSER1 + ", " + PARSER2 + ", " + PARSER3 + ", " + PARSER4 + ", \"@@@\")"
+                PARSER1 + ", " + PARSER2 + ", " + PARSER3 + ", " + PARSER4 + ", \"@@@\""
+        );
+    }
+
+    @Test
+    public void testToStringSurroundAlternativeParser() {
+        this.toStringAndCheck(
+                SequenceParser.with(
+                        Lists.of(
+                                PARSER1,
+                                AlternativesParser.with(
+                                        Lists.of(
+                                                PARSER2,
+                                                PARSER3
+                                        )
+                                ),
+                                PARSER4
+                        )
+                ),
+                PARSER1 + ", (" + PARSER2 + " | " + PARSER3 + "), " + PARSER4
         );
     }
 


### PR DESCRIPTION
- Removed forced "(" and ")" around AlternativesParser#toString and SequenceParser#toString
- AlternativesParser#toString adds "(" and ")" to SequenceParsers
- SequenceParsers#toString adds "(" and ")" to AlternativesParser

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/342
- AlternativeParser & SequenceParser.toString should remove their own grouping parens and wrap child AlternativeParser | SequenceParser