### PR TITLE
https://github.com/mP1/walkingkooka-datetime/pull/76 BasicDateTimeCon…

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTesting.java
@@ -19,6 +19,7 @@ package walkingkooka.text.cursor.parser;
 
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.text.CharSequences;
@@ -28,6 +29,7 @@ import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.printer.TreePrintableTesting;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
@@ -235,8 +237,13 @@ public interface ParserTesting extends TreePrintableTesting {
     }
 
     default DateTimeContext dateTimeContext() {
-        return DateTimeContexts.locale(
-                Locale.ENGLISH,
+        final Locale locale = Locale.ENGLISH;
+
+        return DateTimeContexts.basic(
+                DateTimeSymbols.fromDateFormatSymbols(
+                        new DateFormatSymbols(locale)
+                ),
+                locale,
                 1900,
                 20,
                 LocalDateTime::now

--- a/src/test/java/walkingkooka/text/cursor/parser/BasicParserContextTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BasicParserContextTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.InvalidCharacterException;
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.reflect.ClassTesting2;
@@ -28,6 +29,7 @@ import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.cursor.TextCursor;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.function.BiFunction;
@@ -124,8 +126,12 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
     }
 
     private DateTimeContext dateTimeContext() {
-        return DateTimeContexts.locale(
-                Locale.ENGLISH,
+        final Locale locale = Locale.ENGLISH;
+        return DateTimeContexts.basic(
+                DateTimeSymbols.fromDateFormatSymbols(
+                        new DateFormatSymbols(locale)
+                ),
+                locale,
                 1900,
                 50,
                 LocalDateTime::now

--- a/src/test/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserTestCase2.java
@@ -21,11 +21,13 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursors;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -113,7 +115,10 @@ public abstract class DateTimeFormatterParserTestCase2<P extends DateTimeFormatt
     public ParserContext createContext() {
         return ParserContexts.basic(
                 InvalidCharacterExceptionFactory.POSITION,
-                DateTimeContexts.locale(
+                DateTimeContexts.basic(
+                        DateTimeSymbols.fromDateFormatSymbols(
+                                new DateFormatSymbols(LOCALE)
+                        ),
                         LOCALE,
                         1900,
                         50,

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserContextDelegatorTest.java
@@ -18,11 +18,13 @@
 package walkingkooka.text.cursor.parser;
 
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.text.cursor.parser.ParserContextDelegatorTest.TestParserContextDelegator;
 
 import java.math.MathContext;
+import java.text.DateFormatSymbols;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
@@ -79,10 +81,15 @@ public final class ParserContextDelegatorTest implements ParserContextTesting<Te
     static final class TestParserContextDelegator implements ParserContextDelegator {
         @Override
         public ParserContext parserContext() {
+            final Locale locale = Locale.ENGLISH;
+
             return ParserContexts.basic(
                     InvalidCharacterExceptionFactory.POSITION,
-                    DateTimeContexts.locale(
-                            Locale.ENGLISH,
+                    DateTimeContexts.basic(
+                            DateTimeSymbols.fromDateFormatSymbols(
+                                    new DateFormatSymbols(locale)
+                            ),
+                            locale,
                             1950, // defaultYear
                             50, // twoDigitYear
                             LocalDateTime::now


### PR DESCRIPTION
…text replaces LocaleDateTimeContext uses DateTimeSymbols

- https://github.com/mP1/walkingkooka-datetime/pull/76
- BasicDateTimeContext replaces LocaleDateTimeContext uses DateTimeSymbols