### PR TITLE
LongParser honours DecimalNumberContext.zeroDigit

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/LongParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LongParser.java
@@ -64,6 +64,7 @@ final class LongParser<C extends ParserContext> extends NonEmptyParser<C> implem
         LongParserToken token;
 
         final int radix = this.radix;
+        final boolean radix10 = 10 == radix;
         long number = 0;
         boolean empty = true;
         boolean overflow = false;
@@ -77,8 +78,8 @@ final class LongParser<C extends ParserContext> extends NonEmptyParser<C> implem
                 break;
             }
 
-            char c = cursor.at();
-            if (empty && 10 == radix) {
+            final char c = cursor.at();
+            if (empty && radix10) {
                 if (negativeSign == c) {
                     signed = true;
                     cursor.next();
@@ -90,7 +91,9 @@ final class LongParser<C extends ParserContext> extends NonEmptyParser<C> implem
                     continue;
                 }
             }
-            final int digit = Character.digit(c, radix);
+            final int digit = radix10 ?
+                    context.digit(c) :
+                    Character.digit(c, radix);
             if (-1 == digit) {
                 token = empty ?
                         null :

--- a/src/test/java/walkingkooka/text/cursor/parser/LongParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/LongParserTest.java
@@ -331,10 +331,136 @@ public class LongParserTest extends NonEmptyParserTestCase<LongParser<ParserCont
                             public char positiveSign() {
                                 return 'P';
                             }
+
+                            @Override
+                            public char zeroDigit() {
+                                return '0';
+                            }
                         }
                 ),
                 text,
                 ParserTokens.longParserToken(value, text),
+                text,
+                ""
+        );
+    }
+
+    @Test
+    public void testParseRadix16IgnoresDecimalNumberContextZeroNonArabicDigits() {
+        final char zero = '\u0660';
+        final String text = "ff";
+
+        this.parseAndCheck(
+                LongParser.with(16),
+                ParserContexts.basic(
+                        InvalidCharacterExceptionFactory.POSITION,
+                        DateTimeContexts.fake(),
+                        new FakeDecimalNumberContext() {
+
+                            @Override
+                            public char negativeSign() {
+                                return 'M';
+                            }
+
+                            @Override
+                            public char positiveSign() {
+                                return 'P';
+                            }
+
+                            @Override
+                            public char zeroDigit() {
+                                return zero;
+                            }
+                        }
+                ),
+                text,
+                ParserTokens.longParserToken(
+                        0xff,
+                        text
+                ),
+                text,
+                ""
+        );
+    }
+
+    @Test
+    public void testParseRadix10NonArabicDigits() {
+        final char zero = '\u0660';
+        final String text = new StringBuilder()
+                .append((char) (zero + 1))
+                .append((char) (zero + 2))
+                .toString();
+
+        this.parseAndCheck(
+                this.createParser(),
+                ParserContexts.basic(
+                        InvalidCharacterExceptionFactory.POSITION,
+                        DateTimeContexts.fake(),
+                        new FakeDecimalNumberContext() {
+
+                            @Override
+                            public char negativeSign() {
+                                return 'M';
+                            }
+
+                            @Override
+                            public char positiveSign() {
+                                return 'P';
+                            }
+
+                            @Override
+                            public char zeroDigit() {
+                                return zero;
+                            }
+                        }
+                ),
+                text,
+                ParserTokens.longParserToken(
+                        12,
+                        text
+                ),
+                text,
+                ""
+        );
+    }
+
+    @Test
+    public void testParseRadix10NonArabicDigits2() {
+        final char zero = '\u0660';
+        final String text = new StringBuilder()
+                .append('M')
+                .append((char) (zero + 1))
+                .append((char) (zero + 2))
+                .toString();
+
+        this.parseAndCheck(
+                this.createParser(),
+                ParserContexts.basic(
+                        InvalidCharacterExceptionFactory.POSITION,
+                        DateTimeContexts.fake(),
+                        new FakeDecimalNumberContext() {
+
+                            @Override
+                            public char negativeSign() {
+                                return 'M';
+                            }
+
+                            @Override
+                            public char positiveSign() {
+                                return 'P';
+                            }
+
+                            @Override
+                            public char zeroDigit() {
+                                return zero;
+                            }
+                        }
+                ),
+                text,
+                ParserTokens.longParserToken(
+                        -12,
+                        text
+                ),
                 text,
                 ""
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/373
- LongParser should use DecimalNumberContext.zeroDigit