### PR TITLE
BigIntegerParser honours DecimalNumberContext.zeroDigit

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParser.java
@@ -69,6 +69,8 @@ final class BigIntegerParser<C extends ParserContext> extends NonEmptyParser<C>
         BigIntegerParserToken token;
 
         final int radix = this.radix;
+        final boolean radix10 = 10 == radix;
+
         BigInteger number = BigInteger.ZERO;
         boolean empty = true;
         boolean signed = false;
@@ -85,7 +87,7 @@ final class BigIntegerParser<C extends ParserContext> extends NonEmptyParser<C>
             }
 
             char c = cursor.at();
-            if (empty && 10 == radix) {
+            if (radix10 && empty) {
                 if (negativeSign == c) {
                     signed = true;
                     cursor.next();
@@ -98,7 +100,9 @@ final class BigIntegerParser<C extends ParserContext> extends NonEmptyParser<C>
                 }
             }
 
-            final int digit = Character.digit(c, radix);
+            final int digit = radix10 ?
+                    context.digit(c) :
+                    Character.digit(c, radix);
             if (-1 == digit) {
                 token = empty ?
                         null :

--- a/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTest.java
@@ -250,10 +250,67 @@ public class BigIntegerParserTest extends NonEmptyParserTestCase<BigIntegerParse
         );
     }
 
-    private TextCursor parseAndCheck3(final String text,
-                                      final int value) {
-        return this.parseAndCheck(
+    private final static char ARABIC_INDIC_ZERO = '\u0660';
+
+    @Test
+    public void testParseRadix16IgnoresDecimalNumberContextZeroNonArabicDigits() {
+        final String text = "ff";
+
+        this.parseAndCheck3(
+                BigIntegerParser.with(16),
+                text,
+                ARABIC_INDIC_ZERO,
+                0xff
+        );
+    }
+
+    @Test
+    public void testParseRadix10NonArabicDigits() {
+        final String text = new StringBuilder()
+                .append((char) (ARABIC_INDIC_ZERO + 1))
+                .append((char) (ARABIC_INDIC_ZERO + 2))
+                .toString();
+
+        this.parseAndCheck3(
                 this.createParser(),
+                text,
+                ARABIC_INDIC_ZERO,
+                12
+        );
+    }
+
+    @Test
+    public void testParseRadix10NonArabicDigits2() {
+        final String text = new StringBuilder()
+                .append('M')
+                .append((char) (ARABIC_INDIC_ZERO + 1))
+                .append((char) (ARABIC_INDIC_ZERO + 2))
+                .toString();
+
+        this.parseAndCheck3(
+                this.createParser(),
+                text,
+                ARABIC_INDIC_ZERO,
+                -12
+        );
+    }
+
+    private TextCursor parseAndCheck3(final String text,
+                                      final long expected) {
+        return this.parseAndCheck3(
+                this.createParser(),
+                text,
+                '0',
+                expected
+        );
+    }
+
+    private TextCursor parseAndCheck3(final Parser<ParserContext> parser,
+                                      final String text,
+                                      final char zeroDigit,
+                                      final long expected) {
+        return this.parseAndCheck(
+                parser,
                 ParserContexts.basic(
                         InvalidCharacterExceptionFactory.POSITION,
                         DateTimeContexts.fake(),
@@ -267,11 +324,16 @@ public class BigIntegerParserTest extends NonEmptyParserTestCase<BigIntegerParse
                             public char positiveSign() {
                                 return 'P';
                             }
+
+                            @Override
+                            public char zeroDigit() {
+                                return zeroDigit;
+                            }
                         }
                 ),
                 text,
                 ParserTokens.bigInteger(
-                        BigInteger.valueOf(value),
+                        BigInteger.valueOf(expected),
                         text
                 ),
                 text,


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/371
- BigIntegerParser should use DecimalNumberContext.zeroDigit