### PR TITLE
BigDecimalParser honours DecimalNumberContext.zeroDigit

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BigDecimalParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigDecimalParser.java
@@ -126,7 +126,7 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((NUMBER_DIGIT & mode) != 0) {
-                    final int digit = digit(c);
+                    final int digit = context.digit(c);
                     if (digit >= 0) {
                         cursor.next();
                         number = number(number, digit, mathContext);
@@ -143,7 +143,7 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((DECIMAL_DIGIT & mode) != 0) {
-                    final int digit = digit(c);
+                    final int digit = context.digit(c);
                     if (digit >= 0) {
                         cursor.next();
                         number = number(number, digit, mathContext);
@@ -182,7 +182,7 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((EXPONENT_DIGIT & mode) != 0) {
-                    final int digit = digit(c);
+                    final int digit = context.digit(c);
                     if (digit >= 0) {
                         cursor.next();
                         exponent = exponent(exponent, digit);
@@ -213,10 +213,6 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
         }
 
         return Optional.ofNullable(token);
-    }
-
-    private static int digit(final char c) {
-        return Character.digit(c, RADIX);
     }
 
     private static BigDecimal number(final BigDecimal value,

--- a/src/test/java/walkingkooka/text/cursor/parser/BigDecimalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigDecimalParserTest.java
@@ -430,7 +430,7 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
                                 DecimalNumberSymbols.with(
                                         '+', // negativeSign
                                         '-', // positiveSign
-                                        '1', // zero
+                                        '0', // zero
                                         "C", // currency
                                         '*', // decimalPoint
                                         "X", // exponentSymbol
@@ -480,6 +480,51 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
                 ),
                 text,
                 ParserTokens.bigDecimal(value, text),
+                text,
+                ""
+        );
+    }
+
+    @Test
+    public void testParseNonArabicDigits() {
+        final char zero = '\u0660';
+
+        final String text = new StringBuilder()
+                .append((char) (zero + 1))
+                .append((char) (zero + 2))
+                .append('*')
+                .append((char) (zero + 5))
+                .toString();
+
+        this.parseAndCheck(
+                this.createParser(),
+                ParserContexts.basic(
+                        InvalidCharacterExceptionFactory.POSITION,
+                        DateTimeContexts.fake(),
+                        DecimalNumberContexts.basic(
+                                DecimalNumberSymbols.with(
+                                        '+', // negativeSign
+                                        '-', // positiveSign
+                                        zero, // zeroDigit
+                                        "C", // currency
+                                        '*', // decimalPoint
+                                        "XYZ", // exponentSymbol
+                                        '/', // groupSeparator
+                                        "INFINITY",
+                                        '#', // monetaryDecimal
+                                        "NAN",
+                                        '$', // percent
+                                        '^' // permill
+                                ),
+                                Locale.ENGLISH,
+                                MathContext.DECIMAL32
+                        )
+                ),
+                text,
+                ParserTokens.bigDecimal(
+                        BigDecimal.valueOf(12.5),
+                        text
+                ),
                 text,
                 ""
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/374
- BigDecimalParser should use DecimalNumberContext.zeroDigit