### PR TITLE
DoubleParser honours DecimalNumberContext.zeroDigit

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/DoubleParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DoubleParser.java
@@ -87,6 +87,7 @@ final class DoubleParser<C extends ParserContext> extends NonEmptyParser<C>
         final char negativeSign = context.negativeSign();
         final char positiveSign = context.positiveSign();
         final String exponentSymbol = context.exponentSymbol();
+        final char zero = context.zeroDigit();
 
         Optional<ParserToken> token = Optional.empty();
 
@@ -156,7 +157,7 @@ final class DoubleParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((NUMBER_ZERO & mode) != 0) {
-                    if ('0' == c) {
+                    if (zero == c) {
                         cursor.next();
                         mode = DECIMAL | EXPONENT;
                         empty = false;
@@ -164,7 +165,7 @@ final class DoubleParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((NUMBER_DIGIT & mode) != 0) {
-                    final int digit = digit(c);
+                    final int digit = context.digit(c);
                     if (digit >= 0) {
                         cursor.next();
                         number = number(number, digit);
@@ -181,7 +182,7 @@ final class DoubleParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((DECIMAL_DIGIT & mode) != 0) {
-                    final int digit = digit(c);
+                    final int digit = context.digit(c);
                     if (digit >= 0) {
                         cursor.next();
                         number = number(number, digit);
@@ -220,7 +221,7 @@ final class DoubleParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((EXPONENT_DIGIT & mode) != 0) {
-                    final int digit = digit(c);
+                    final int digit = context.digit(c);
                     if (digit >= 0) {
                         cursor.next();
                         exponent = exponent(exponent, digit);
@@ -326,10 +327,6 @@ final class DoubleParser<C extends ParserContext> extends NonEmptyParser<C>
         }
 
         return token;
-    }
-
-    private static int digit(final char c) {
-        return Character.digit(c, RADIX);
     }
 
     private static double number(final double value, final int digit) {

--- a/src/test/java/walkingkooka/text/cursor/parser/DoubleParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DoubleParserTest.java
@@ -19,8 +19,13 @@ package walkingkooka.text.cursor.parser;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.math.DecimalNumberSymbols;
 import walkingkooka.math.FakeDecimalNumberContext;
 import walkingkooka.text.cursor.TextCursor;
+
+import java.math.MathContext;
+import java.util.Locale;
 
 public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<ParserContext>, DoubleParserToken> {
 
@@ -748,6 +753,11 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
                             public char positiveSign() {
                                 return 'P';
                             }
+
+                            @Override
+                            public char zeroDigit() {
+                                return '0';
+                            }
                         }
                 ),
                 text,
@@ -783,6 +793,11 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
                             @Override
                             public char positiveSign() {
                                 return 'P';
+                            }
+
+                            @Override
+                            public char zeroDigit() {
+                                return '0';
                             }
                         }
                 ),
@@ -827,6 +842,51 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
                 ),
                 text,
                 textAfter
+        );
+    }
+
+    @Test
+    public void testParseNonArabicDigits() {
+        final char zero = '\u0660';
+
+        final String text = new StringBuilder()
+                .append((char) (zero + 1))
+                .append((char) (zero + 2))
+                .append('*')
+                .append((char) (zero + 5))
+                .toString();
+
+        this.parseAndCheck(
+                this.createParser(),
+                ParserContexts.basic(
+                        InvalidCharacterExceptionFactory.POSITION,
+                        DateTimeContexts.fake(),
+                        DecimalNumberContexts.basic(
+                                DecimalNumberSymbols.with(
+                                        '+', // negativeSign
+                                        '-', // positiveSign
+                                        zero, // zeroDigit
+                                        "C", // currency
+                                        '*', // decimalPoint
+                                        "XYZ", // exponentSymbol
+                                        '/', // groupSeparator
+                                        "INFINITY",
+                                        '#', // monetaryDecimal
+                                        "NAN",
+                                        '$', // percent
+                                        '^' // permill
+                                ),
+                                Locale.ENGLISH,
+                                MathContext.DECIMAL32
+                        )
+                ),
+                text,
+                ParserTokens.doubleParserToken(
+                        12.5,
+                        text
+                ),
+                text,
+                ""
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/372
- DoubleParser should use DecimalNumberContext.zeroDigit