### PR TITLE
BigDecimalParser Context.zeroDigit() replaces zero character literal

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BigDecimalParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigDecimalParser.java
@@ -75,6 +75,7 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
         final int negativeSign = context.negativeSign();
         final int positiveSign = context.positiveSign();
         final String exponentSymbol = context.exponentSymbol();
+        final char zeroDigit = context.zeroDigit();
 
         final MathContext mathContext = context.mathContext();
 
@@ -118,7 +119,7 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((NUMBER_ZERO & mode) != 0) {
-                    if ('0' == c) {
+                    if (zeroDigit == c) {
                         cursor.next();
                         mode = NUMBER_ZERO | NUMBER_DIGIT | DECIMAL | EXPONENT;
                         empty = false;
@@ -162,7 +163,7 @@ final class BigDecimalParser<C extends ParserContext> extends NonEmptyParser<C>
                     }
                 }
                 if ((EXPONENT_ZERO & mode) != 0) {
-                    if ('0' == c) {
+                    if (zeroDigit == c) {
                         cursor.next();
                         mode = FINISH;
                         break;

--- a/src/test/java/walkingkooka/text/cursor/parser/BigDecimalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigDecimalParserTest.java
@@ -486,7 +486,92 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
     }
 
     @Test
-    public void testParseNonArabicDigits() {
+    public void testParseZeroWithNonArabicDigits() {
+        final char zero = ARABIC_ZERO_DIGIT;
+
+        final String text = "" + zero;
+
+        this.parseAndCheck(
+            this.createParser(),
+            ParserContexts.basic(
+                InvalidCharacterExceptionFactory.POSITION,
+                DateTimeContexts.fake(),
+                DecimalNumberContexts.basic(
+                    DecimalNumberSymbols.with(
+                        '+', // negativeSign
+                        '-', // positiveSign
+                        zero, // zeroDigit
+                        "C", // currency
+                        '*', // decimalPoint
+                        "XYZ", // exponentSymbol
+                        '/', // groupSeparator
+                        "INFINITY",
+                        '#', // monetaryDecimal
+                        "NAN",
+                        '$', // percent
+                        '^' // permill
+                    ),
+                    Locale.ENGLISH,
+                    MathContext.DECIMAL32
+                )
+            ),
+            text,
+            ParserTokens.bigDecimal(
+                BigDecimal.ZERO,
+                text
+            ),
+            text,
+            ""
+        );
+    }
+
+    @Test
+    public void testParseNumberExponentZeroWithNonArabicDigits() {
+        final char zero = ARABIC_ZERO_DIGIT;
+
+        final String text = new StringBuilder()
+            .append((char) (zero + 1))
+            .append((char) (zero + 2))
+            .append("XYZ")
+            .append(zero)
+            .toString();
+
+        this.parseAndCheck(
+            this.createParser(),
+            ParserContexts.basic(
+                InvalidCharacterExceptionFactory.POSITION,
+                DateTimeContexts.fake(),
+                DecimalNumberContexts.basic(
+                    DecimalNumberSymbols.with(
+                        '+', // negativeSign
+                        '-', // positiveSign
+                        zero, // zeroDigit
+                        "C", // currency
+                        '*', // decimalPoint
+                        "XYZ", // exponentSymbol
+                        '/', // groupSeparator
+                        "INFINITY",
+                        '#', // monetaryDecimal
+                        "NAN",
+                        '$', // percent
+                        '^' // permill
+                    ),
+                    Locale.ENGLISH,
+                    MathContext.DECIMAL32
+                )
+            ),
+            text,
+            ParserTokens.bigDecimal(
+                BigDecimal.valueOf(12),
+                text
+            ),
+            text,
+            ""
+        );
+    }
+
+    @Test
+    public void testParseDecimalNumberWithNonArabicDigits() {
         final char zero = ARABIC_ZERO_DIGIT;
 
         final String text = new StringBuilder()


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/404
- BigDecimalParser includes zero literal should use Context.zeroDigit()