### PR TITLE
ParserContext.isGroupSeparatorWithinNumbersSupported

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -47,6 +47,7 @@ public class TestGwtTest extends GWTTestCase {
                         InvalidCharacterExceptionFactory.POSITION,
                         DateTimeContexts.fake(),
                         DecimalNumberContexts.basic(
+                            false, // false == isGroupSeparatorWithinNumbersSupported
                             DecimalNumberSymbols.with(
                                 '-',
                                 '+',

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -52,6 +52,7 @@ public class JunitTest {
                 .parse(
                     TextCursors.charSequence(text),
                     ParserContexts.basic(
+                        false, // false == isGroupSeparatorWithinNumbersSupported
                         InvalidCharacterExceptionFactory.POSITION,
                         DateTimeContexts.fake(),
                         DecimalNumberContexts.basic(

--- a/src/main/java/walkingkooka/text/cursor/parser/BasicParserContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BasicParserContext.java
@@ -38,7 +38,8 @@ final class BasicParserContext implements ParserContext,
     /**
      * Creates a new {@link BasicParserContext}.
      */
-    static BasicParserContext with(final BiFunction<Parser<?>, TextCursor, InvalidCharacterException> invalidCharacterExceptionFactory,
+    static BasicParserContext with(final boolean isGroupSeparatorWithinNumbersSupported,
+                                   final BiFunction<Parser<?>, TextCursor, InvalidCharacterException> invalidCharacterExceptionFactory,
                                    final DateTimeContext dateTimeContext,
                                    final DecimalNumberContext decimalNumberContext) {
         Objects.requireNonNull(invalidCharacterExceptionFactory, "invalidCharacterExceptionFactory");
@@ -46,6 +47,7 @@ final class BasicParserContext implements ParserContext,
         Objects.requireNonNull(decimalNumberContext, "decimalNumberContext");
 
         return new BasicParserContext(
+            isGroupSeparatorWithinNumbersSupported,
             invalidCharacterExceptionFactory,
             dateTimeContext,
             decimalNumberContext
@@ -55,15 +57,24 @@ final class BasicParserContext implements ParserContext,
     /**
      * Private ctor use factory
      */
-    private BasicParserContext(final BiFunction<Parser<?>, TextCursor, InvalidCharacterException> invalidCharacterExceptionFactory,
+    private BasicParserContext(final boolean isGroupSeparatorWithinNumbersSupported,
+                               final BiFunction<Parser<?>, TextCursor, InvalidCharacterException> invalidCharacterExceptionFactory,
                                final DateTimeContext dateTimeContext,
                                final DecimalNumberContext decimalNumberContext) {
         super();
 
+        this.isGroupSeparatorWithinNumbersSupported = isGroupSeparatorWithinNumbersSupported;
         this.invalidCharacterExceptionFactory = invalidCharacterExceptionFactory;
         this.dateTimeContext = dateTimeContext;
         this.decimalNumberContext = decimalNumberContext;
     }
+
+    @Override
+    public boolean isGroupSeparatorWithinNumbersSupported() {
+        return this.isGroupSeparatorWithinNumbersSupported;
+    }
+
+    private final boolean isGroupSeparatorWithinNumbersSupported;
 
     @Override
     public InvalidCharacterException invalidCharacterException(final Parser<?> parser,
@@ -101,6 +112,10 @@ final class BasicParserContext implements ParserContext,
 
     @Override
     public String toString() {
-        return this.dateTimeContext + " " + this.decimalNumberContext;
+        return "isGroupSeparatorWithinNumbersSupported: " + isGroupSeparatorWithinNumbersSupported +
+            " " +
+            this.dateTimeContext +
+            " " +
+            this.decimalNumberContext;
     }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/FakeParserContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/FakeParserContext.java
@@ -34,6 +34,11 @@ public class FakeParserContext extends FakeDecimalNumberContext implements Parse
     // ParserContext....................................................................................................
 
     @Override
+    public boolean isGroupSeparatorWithinNumbersSupported() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public InvalidCharacterException invalidCharacterException(final Parser<?> parser,
                                                                final TextCursor cursor) {
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserContext.java
@@ -29,6 +29,12 @@ public interface ParserContext extends DateTimeContext,
     DecimalNumberContext {
 
     /**
+     * When true numbers may contain the {@link #groupSeparator()} which will be ignored when computing the actual
+     * numeric value.
+     */
+    boolean isGroupSeparatorWithinNumbersSupported();
+
+    /**
      * Factory that creates a {@link InvalidCharacterException} for the current {@link TextCursor#at()}.
      * The context is able to custom whether the message will include the position or text offset or column and line.
      */

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserContextDelegator.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserContextDelegator.java
@@ -41,6 +41,12 @@ public interface ParserContextDelegator extends ParserContext,
     }
 
     @Override
+    default boolean isGroupSeparatorWithinNumbersSupported() {
+        return this.parserContext()
+            .isGroupSeparatorWithinNumbersSupported();
+    }
+
+    @Override
     default InvalidCharacterException invalidCharacterException(final Parser<?> parser,
                                                                 final TextCursor cursor) {
         return this.parserContext()

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserContexts.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserContexts.java
@@ -32,10 +32,12 @@ public final class ParserContexts implements PublicStaticHelper {
     /**
      * {@see BasicParserContext}
      */
-    public static ParserContext basic(final BiFunction<Parser<?>, TextCursor, InvalidCharacterException> invalidCharacterExceptionFactory,
+    public static ParserContext basic(final boolean isGroupSeparatorWithinNumbersSupported,
+                                      final BiFunction<Parser<?>, TextCursor, InvalidCharacterException> invalidCharacterExceptionFactory,
                                       final DateTimeContext dateTimeContext,
                                       final DecimalNumberContext decimalNumberContext) {
         return BasicParserContext.with(
+            isGroupSeparatorWithinNumbersSupported,
             invalidCharacterExceptionFactory,
             dateTimeContext,
             decimalNumberContext

--- a/src/test/java/walkingkooka/text/cursor/parser/BasicParserContextTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BasicParserContextTest.java
@@ -42,6 +42,8 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
     ParserContextTesting<BasicParserContext>,
     DecimalNumberContextDelegator {
 
+    private final static boolean IS_GROUP_SEPARATOR_WITHIN_NUMBERS_SUPPORTED = false;
+
     private final static BiFunction<Parser<?>, TextCursor, InvalidCharacterException> INVALID_CHARACTER_EXCEPTION_FACTORY =
         (final Parser<?> parser,
          final TextCursor cursor) -> new InvalidCharacterException(
@@ -72,6 +74,7 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
         assertThrows(
             NullPointerException.class,
             () -> BasicParserContext.with(
+                IS_GROUP_SEPARATOR_WITHIN_NUMBERS_SUPPORTED,
                 null,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.fake()
@@ -84,6 +87,7 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
         assertThrows(
             NullPointerException.class,
             () -> BasicParserContext.with(
+                IS_GROUP_SEPARATOR_WITHIN_NUMBERS_SUPPORTED,
                 INVALID_CHARACTER_EXCEPTION_FACTORY,
                 null,
                 DecimalNumberContexts.fake()
@@ -96,6 +100,7 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
         assertThrows(
             NullPointerException.class,
             () -> BasicParserContext.with(
+                IS_GROUP_SEPARATOR_WITHIN_NUMBERS_SUPPORTED,
                 INVALID_CHARACTER_EXCEPTION_FACTORY,
                 DateTimeContexts.fake(),
                 null
@@ -127,6 +132,7 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
     @Override
     public BasicParserContext createContext() {
         return BasicParserContext.with(
+            IS_GROUP_SEPARATOR_WITHIN_NUMBERS_SUPPORTED,
             INVALID_CHARACTER_EXCEPTION_FACTORY,
             this.dateTimeContext(),
             this.decimalNumberContext()
@@ -179,7 +185,10 @@ public final class BasicParserContextTest implements ClassTesting2<BasicParserCo
     public void testToString() {
         this.toStringAndCheck(
             this.createContext(),
-            this.dateTimeContext() + " " + this.decimalNumberContext()
+            "isGroupSeparatorWithinNumbersSupported: false " +
+                this.dateTimeContext() +
+                " " +
+                this.decimalNumberContext()
         );
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/BigDecimalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigDecimalParserTest.java
@@ -95,6 +95,15 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
     }
 
     @Test
+    public void testParseGroupSeparatorWhenIsGroupSeparatorWithinNumbersSupportedFalseFails() {
+        this.parseAndCheck2(
+            "12",
+            BigDecimal.valueOf(12),
+            ",34"
+        );
+    }
+
+    @Test
     public void testParsePlusZeroDecimal() {
         this.parseAndCheck2("+0.");
     }
@@ -122,6 +131,37 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
     @Test
     public void testParseZeroDecimal2() {
         this.parseAndCheck2("0.", "~");
+    }
+
+    // group-separator not consumed.
+
+    @Test
+    public void testParseZeroDecimalFractionGroupSeparatorWhenIsGroupSeparatorWithinNumbersSupportedFalse() {
+        this.parseAndCheck(
+            this.createParser(),
+            this.createContext(false), // isGroupSeparatorWithinNumbersSupported
+            "0.5,",
+            ParserTokens.bigDecimal(
+                BigDecimal.valueOf(0.5),
+                "0.5"
+            ),
+            "0.5",
+            ","
+        );
+    }
+
+    @Test
+    public void testParseZeroDecimalFractionGroupSeparatorWhenIsGroupSeparatorWithinNumbersSupportedTrue() {
+        this.parseAndCheck(
+            this.createParser(),
+            this.createContext(true), // isGroupSeparatorWithinNumbersSupported
+            "0.5,",
+            ParserTokens.bigDecimal(
+                BigDecimal.valueOf(0.5), "0.5"
+            ),
+            "0.5",
+            ","
+        );
     }
 
     @Test
@@ -257,6 +297,22 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
     @Test
     public void testParseMinusZeroDecimalZeroes() {
         this.parseAndCheck2("-0.0000");
+    }
+
+    @Test
+    public void testParseZeroGroupSeparatorZeroWhenIsGroupSeparatorWithinNumbersSupportedTrue() {
+        final String text = "1,234";
+
+        this.parseAndCheck(
+            this.createParser(),
+            this.createContext(true), // IsGroupSeparatorWithinNumbersSupported=true
+            text,
+            ParserTokens.bigDecimal(
+                BigDecimal.valueOf(1234),
+                text
+            ),
+            text
+        );
     }
 
     @Test
@@ -424,6 +480,7 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
         return this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.basic(
@@ -457,6 +514,7 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
         return this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.basic(
@@ -494,6 +552,7 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
         this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.basic(
@@ -539,6 +598,7 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
         this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.basic(
@@ -584,6 +644,7 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
         this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.basic(
@@ -622,7 +683,14 @@ public final class BigDecimalParserTest extends NonEmptyParserTestCase<BigDecima
 
     @Override
     public ParserContext createContext() {
+        return this.createContext(
+            false // isGroupSeparatorWithinNumbersSupported
+        );
+    }
+
+    private ParserContext createContext(final boolean isGroupSeparatorWithinNumbersSupported) {
         return ParserContexts.basic(
+            isGroupSeparatorWithinNumbersSupported,
             InvalidCharacterExceptionFactory.POSITION,
             DateTimeContexts.fake(),
             this.decimalNumberContext()

--- a/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTest.java
@@ -302,6 +302,7 @@ public class BigIntegerParserTest extends NonEmptyParserTestCase<BigIntegerParse
         return this.parseAndCheck(
             parser,
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 new FakeDecimalNumberContext() {
@@ -339,6 +340,7 @@ public class BigIntegerParserTest extends NonEmptyParserTestCase<BigIntegerParse
     @Override
     public ParserContext createContext() {
         return ParserContexts.basic(
+            false, // isGroupSeparatorWithinNumbersSupported
             InvalidCharacterExceptionFactory.POSITION,
             DateTimeContexts.fake(),
             this.decimalNumberContext()

--- a/src/test/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DateTimeFormatterParserTestCase2.java
@@ -115,6 +115,7 @@ public abstract class DateTimeFormatterParserTestCase2<P extends DateTimeFormatt
     @Override
     public ParserContext createContext() {
         return ParserContexts.basic(
+            false, // isGroupSeparatorWithinNumbersSupported
             InvalidCharacterExceptionFactory.POSITION,
             DateTimeContexts.basic(
                 DateTimeSymbols.fromDateFormatSymbols(

--- a/src/test/java/walkingkooka/text/cursor/parser/DoubleParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DoubleParserTest.java
@@ -732,6 +732,7 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
         return this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 new FakeDecimalNumberContext() {
@@ -773,6 +774,7 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
         return this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 new FakeDecimalNumberContext() {
@@ -817,6 +819,7 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
     @Override
     public ParserContext createContext() {
         return ParserContexts.basic(
+            false, // isGroupSeparatorWithinNumbersSupported,
             InvalidCharacterExceptionFactory.POSITION,
             this.dateTimeContext(),
             this.decimalNumberContext()
@@ -860,6 +863,7 @@ public final class DoubleParserTest extends NonEmptyParserTestCase<DoubleParser<
         this.parseAndCheck(
             this.createParser(),
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 DecimalNumberContexts.basic(

--- a/src/test/java/walkingkooka/text/cursor/parser/LongParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/LongParserTest.java
@@ -363,6 +363,7 @@ public class LongParserTest extends NonEmptyParserTestCase<LongParser<ParserCont
         return this.parseAndCheck(
             parser,
             ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 new FakeDecimalNumberContext() {
@@ -400,6 +401,7 @@ public class LongParserTest extends NonEmptyParserTestCase<LongParser<ParserCont
     @Override
     public ParserContext createContext() {
         return ParserContexts.basic(
+            false, // isGroupSeparatorWithinNumbersSupported
             InvalidCharacterExceptionFactory.POSITION,
             DateTimeContexts.fake(),
             this.decimalNumberContext()

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserContextDelegatorTest.java
@@ -55,6 +55,7 @@ public final class ParserContextDelegatorTest implements ParserContextTesting<Te
             final Locale locale = Locale.ENGLISH;
 
             return ParserContexts.basic(
+                false, // isGroupSeparatorWithinNumbersSupported
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.basic(
                     DateTimeSymbols.fromDateFormatSymbols(

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTest.java
@@ -203,6 +203,7 @@ public final class ParserTest implements ClassTesting<Parser<ParserContext>>,
             .parseText(
                 text,
                 ParserContexts.basic(
+                    false, // isGroupSeparatorWithinNumbersSupported
                     InvalidCharacterExceptionFactory.POSITION,
                     DateTimeContexts.fake(),
                     DecimalNumberContexts.american(MathContext.DECIMAL32)

--- a/src/test/java/walkingkooka/text/cursor/parser/sample/Sample.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/sample/Sample.java
@@ -48,6 +48,7 @@ public class Sample {
             Parsers.bigInteger(10)
                 .parse(TextCursors.charSequence(text),
                     ParserContexts.basic(
+                        false, // false == isGroupSeparatorWithinNumbersSupported
                         InvalidCharacterExceptionFactory.POSITION,
                         DateTimeContexts.fake(),
                         DecimalNumberContexts.basic(


### PR DESCRIPTION
- BigDecimalParser now supports groupSeparator when ParserContext.isGroupSeparatorWithinNumbersSupported returns true

- Closes https://github.com/mP1/walkingkooka-text-cursor-parser/issues/403
- ParserContext.isGroupSeparatorWithinNumbersSupported